### PR TITLE
task/ Bug during getPatientInfo from AR add view

### DIFF
--- a/bika/health/content/analysisrequest.py
+++ b/bika/health/content/analysisrequest.py
@@ -175,7 +175,7 @@ class AnalysisRequestSchemaExtender(object):
                                     'align': 'left'},
                     {'columnName': 'UID', 'hidden': True},
                 ],
-                ui_item='ClientPatientID',
+                ui_item='getClientPatientID',
                 search_query='',
                 discard_empty=('ClientPatientID',),
                 search_fields=('ClientPatientID',),

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -83,7 +83,7 @@ function HealthAnalysisRequestAddView() {
      * Searches a patient using the Patient UID from Client Patient Input.
      * If found, fill the Patient's input fields from the same AR add column.
      *  If no patient found, set the values to Anonymous.
-     * @param id Client Patient ID
+     * @param id Patient UID
      * @param colposition AR add column position
      */
     function loadPatient(id, colposition) {

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -80,9 +80,9 @@ function HealthAnalysisRequestAddView() {
     // PRIVATE FUNCTIONS
     // ------------------------------------------------------------------------
     /**
-     * Searches a patient using the Client Patient ID. If found, fill the Patient's input
-     * fields from the same AR add column. If no patient found, set the values to
-     * Anonymous.
+     * Searches a patient using the Patient UID from Client Patient Input.
+     * If found, fill the Patient's input fields from the same AR add column.
+     *  If no patient found, set the values to Anonymous.
      * @param id Client Patient ID
      * @param colposition AR add column position
      */

--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -36,7 +36,8 @@ function HealthAnalysisRequestAddView() {
                 if (colposition == undefined){
                     // we are on the specific health template
                     colposition = 0}
-                loadPatient($(this).val(), colposition);
+                uid = $("#" + this.id + "_uid").val();
+                loadPatient(uid, colposition);
                 checkClientContacts();
             });
 
@@ -92,7 +93,7 @@ function HealthAnalysisRequestAddView() {
                 type: 'POST',
                 data: {
                     '_authenticator': $('input[name="_authenticator"]').val(),
-                    'ClientPatientID': id
+                    'PatientUID': id
                 },
                 dataType: "json",
                 success: function (data, textStatus, $XHR) {


### PR DESCRIPTION
When clicking Client Patient ID, now we get Patient info properly. However, after selecting the Patient, although this field is not empty, error message- about not leaving this field empty, still occurs.