### PR TITLE
NMRL-125 adding ar without client patient

### DIFF
--- a/bika/health/static/js/bika.health.analysisrequest.add.js
+++ b/bika/health/static/js/bika.health.analysisrequest.add.js
@@ -12,6 +12,7 @@ function HealthAnalysisRequestAddView() {
         datafilled = false;
         frombatch = window.location.href.search('/batches/') >= 0;
         frompatient = document.referrer.search('/patients/') >= 0;
+        fromars = window.location.href.search('/analysisrequests/') >=0;
 
         if (frombatch) {
             // The current AR add View comes from a batch. Automatically fill
@@ -25,6 +26,15 @@ function HealthAnalysisRequestAddView() {
             // as readonly.
             pid = document.referrer.split("/patients/")[1].split("/")[0];
             datafilled = fillDataFromPatient(pid);
+        } else if(fromars){
+          $('input[id^="Client-"]').bind("selected paste blur change", function () {
+              colposition = get_arnum(this);
+              if (colposition == undefined){
+                  // we are on the specific health template
+                  colposition = 0}
+              resetPatientData(colposition)
+              filterComboSearches();
+          });
         }
 
         if (!datafilled) {
@@ -110,6 +120,13 @@ function HealthAnalysisRequestAddView() {
                             .attr('uid', 'anonymous');
                         $("#Patient-" + colposition + "_uid").val('anonymous');
                     }
+                    if (data['ClientUID'] != '') {
+                        $("#Client-" + colposition)
+                            .val(data['ClientTitle'])
+                            .attr('uid', data['ClientUID'])
+                            .combogrid("option", "disabled", false);
+                        $("#Client-" + colposition + "_uid").val(data['ClientUID']);
+                    }
                 }
             });
         } else {
@@ -144,6 +161,11 @@ function HealthAnalysisRequestAddView() {
                     $("#ClientPatientID-" + colposition).val(data['ClientPatientID']);
                     $("#ClientPatientID-" + colposition).attr('uid', uid);
                     $("#ClientPatientID-" + colposition + "_uid").val(uid);
+                    $("#Client-" + colposition)
+                        .val(data['ClientTitle'])
+                        .attr('uid', data['ClientUID'])
+                        .combogrid("option", "disabled", false);
+                    $("#Client-" + colposition + "_uid").val(data['ClientUID']);
                 }
             });
         } else {


### PR DESCRIPTION
There should be a very simple way to allow users to register specimen, assign it to a patient, assign a patient to a client, as well as request for analysis. The analysis request form should behave in a similar way as the case form
The requirement is to have analysis request form detached from either the client or patient. At the moment, to create an analysis you have to be either in the client or patient container. Ideally, we want one to open analysis request form, without going to patient or client. From the analysis request form the user should be able to then select or create a patient as well as select a client (following province → district → client hierarchy) both of which are mandatory. In case of missing patient information, register the sample using anonymous patient to allow the sample to be registered and rejected for lack of patient information (the functionality partially exist). The case and the analysis request forms should be maintained as is – except for changes to be made to the actual fields to meet the requirements.
New Analysis Request Add form from outside the client and case. Order of the fields:
1. Patient (search/add)
2. Patient ID (autofill from patient)
3. Referrer/Client (search/add/autofill from patient)
4. Sampling Point
5. Contact (autofill from referrer/client)
6. Sample Type
7. Sampling Date
8. AR Template
9. AR Profile
Technical approach
An “Add” button will be added in the Analysis Requests list view. Thus, the user will be able to create an Analysis Request from outside a Client or Patient view. If so, the Analysis Request Add form will display the Client and Patient fields empty, but both mandatory.