### PR TITLE
NMRL-209 Unexpected argument + NMRL-210 Can't pickle BikaPatientCatalog

### DIFF
--- a/bika/health/catalog/patient_catalog.py
+++ b/bika/health/catalog/patient_catalog.py
@@ -102,7 +102,6 @@ InitializeClass(BikaHealthCatalogPatientListing)
 
 
 # TODO: Remove BikaPatientCatalog
-@deprecated('Flagged in 17.03')
 class BikaPatientCatalog(CatalogTool):
 
     """ Catalog for patients

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -354,8 +354,9 @@ def setupHealthCatalogs(context):
 
     # CATALOG_PATIENTS and analysis requests new columns/indexes
     setup_catalogs(
-        portal, getCatalogDefinitions(),
-        catalog_extensions=getCatalogExtensions())
+        portal=portal,
+        catalogs_definition=getCatalogDefinitions(),
+        catalogs_extension=getCatalogExtensions())
 
 
 def setupHealthTestContent(context):


### PR DESCRIPTION
Fixes the following errors:
```
2017-03-26 11:16:13 ERROR Zope.SiteErrorLog 1490519773.320.332834929961 http://localhost:8080/@@plone-addsite
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.browser.admin, line 211, in __call__
  Module Products.CMFPlone.factory, line 111, in addPloneSite
  Module Products.GenericSetup.tool, line 379, in runAllImportStepsFromProfile
   - __traceback_info__: profile-bika.health:default
  Module Products.GenericSetup.tool, line 1414, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1226, in _doRunImportStep
   - __traceback_info__: setupHealthCatalogs
  Module bika.health.setuphandlers, line 358, in setupHealthCatalogs
TypeError: setup_catalogs() got an unexpected keyword argument 'catalog_extensions'
```
and
```
2017-03-26 11:27:29 ERROR Zope.SiteErrorLog 1490520449.570.78424591267 http://localhost:8080/@@plone-addsite
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.browser.admin, line 211, in __call__
  Module Products.CMFPlone.factory, line 111, in addPloneSite
  Module Products.GenericSetup.tool, line 379, in runAllImportStepsFromProfile
   - __traceback_info__: profile-bika.health:default
  Module Products.GenericSetup.tool, line 1414, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1226, in _doRunImportStep
   - __traceback_info__: content
  Module Products.CMFCore.exportimport.content, line 39, in importSiteStructure
  Module Products.CMFCore.exportimport.content, line 237, in import_
  Module Products.GenericSetup.content, line 415, in import_
  Module Products.Archetypes.WebDAVSupport, line 130, in PUT
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module Products.CMFEditions.subscriber, line 60, in objectInitialized
  Module Products.CMFEditions.subscriber, line 44, in webdavObjectEventHandler
  Module Products.CMFEditions.utilities, line 123, in maybeSaveVersion
  Module Products.CMFEditions.CopyModifyMergeRepositoryTool, line 301, in save
  Module transaction._manager, line 101, in savepoint
  Module transaction._transaction, line 260, in savepoint
  Module transaction._transaction, line 257, in savepoint
  Module transaction._transaction, line 690, in __init__
  Module ZODB.Connection, line 1123, in savepoint
  Module ZODB.Connection, line 623, in _commit
  Module ZODB.Connection, line 658, in _store_objects
  Module ZODB.serialize, line 422, in serialize
  Module ZODB.serialize, line 431, in _dump
PicklingError: Can't pickle <class 'bika.health.catalog.patient_catalog.BikaPatientCatalog'>: it's not the same object as bika.health.catalog.patient_catalog.BikaPatientCatalog
```