### PR TITLE
NMRL-216 System throwing error on saving case

### DIFF
--- a/bika/health/browser/batch/analysisrequests.py
+++ b/bika/health/browser/batch/analysisrequests.py
@@ -10,7 +10,4 @@ class BatchAnalysisRequestsView(BaseBatchARView, HealthAnalysisRequestView):
 
     def __init__(self, context, request):
         super(BatchAnalysisRequestsView, self).__init__(context, request)
-        # Remove Case ID column
-        del self.columns['BatchID']
-        for rs in self.review_states:
-            del rs['columns'][rs['columns'].index('BatchID')]
+        self.columns['BatchID']['toggle'] = False


### PR DESCRIPTION
The system is throwing the error message below on saving cases. Please note that the cases would have been saved despite getting the error message but the user will have to go to the cases page to add another case. 

```
You are here: Home > Cases > C17-2688
We're sorry, but there seems to be an error:

Here is the full error message:

Display traceback as text

Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module bika.health.browser.batch.analysisrequests, line 9, in __call__
    Module bika.lims.browser.batch.analysisrequests, line 40, in __call__
    Module bika.lims.browser.analysisrequest.analysisrequests, line 1053, in __call__
    Module bika.lims.browser.bika_listing, line 786, in __call__
    Module Products.Five.browser.pagetemplatefile, line 125, in __call__
    Module Products.Five.browser.pagetemplatefile, line 59, in __call__
    Module zope.pagetemplate.pagetemplate, line 132, in pt_render
    Module five.pt.engine, line 98, in __call__
    Module z3c.pt.pagetemplate, line 163, in render
    Module chameleon.zpt.template, line 289, in render
    Module chameleon.template, line 191, in render
    Module chameleon.template, line 171, in render
    Module 94503dd4be7f47d16487764d9daf1179.py, line 520, in render
    Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 1172, in render_master
    Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 484, in render_content
    Module 94503dd4be7f47d16487764d9daf1179.py, line 450, in __fill_content_core
    Module five.pt.expressions, line 161, in __call__
    Module bika.lims.browser.bika_listing, line 1257, in contents_table
    Module bika.lims.browser.bika_listing, line 1418, in __init__
    Module bika.health.browser.analysisrequests.view, line 32, in folderitems

ValueError: 'BatchID' is not in list
```