### PR TITLE
NMRL-256 Batch View. CatalogError: Unknown sort_on index (BatchID)

### DIFF
--- a/bika/health/browser/batch/batchfolder.py
+++ b/bika/health/browser/batch/batchfolder.py
@@ -17,6 +17,7 @@ class BatchFolderContentsView(BaseView):
             'Client': {'title': _('Client')},
             'OnsetDate': {'title': _('Onset Date')},
             'state_title': {'title': _('State'), 'sortable': False},
+            'created': {'title': _('Created'), },
          }
         self.review_states = [  # leave these titles and ids alone
             {'id':'default',
@@ -107,7 +108,6 @@ class BatchFolderContentsView(BaseView):
                 del rs['columns'][rs['columns'].index('getClientPatientID')]
                 del rs['columns'][rs['columns'].index('Patient')]
                 del rs['columns'][rs['columns'].index('getPatientID')]
-
         for x in range(len(items)):
             if 'obj' not in items[x]:
                 continue


### PR DESCRIPTION
Accept with https://github.com/naralabs/bika.lims/pull/78

```
CatalogError: Unknown sort_on index (BatchID)
(10 additional frame(s) were not displayed)
...
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/bika_listing.py", line 1077, in _folderitems
    brains = self.contentsMethod(contentFilterTemp)
  File "home/lims/Plone/buildout-cache/eggs/Products.CMFPlone-4.3.10rc1-py2.7.egg/Products/CMFPlone/CatalogTool.py", line 389, in searchResults
    return ZCatalog.searchResults(self, REQUEST, **kw)
  File "home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/ZCatalog.py", line 604, in searchResults
    return self._catalog.searchResults(REQUEST, used, **kw)
  File "home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/Catalog.py", line 916, in searchResults
    sort_index = self._getSortIndex(args)
  File "home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/Catalog.py", line 889, in _getSortIndex
    sort_index_name)

1491718106.190.762233876713 http://10.39.1.21/batches/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.batchfolder, line 106, in __call__
  Module bika.lims.browser.bika_listing, line 784, in __call__
  Module bika.lims.browser.bika_listing, line 1257, in contents_table
  Module bika.lims.browser.bika_listing, line 1418, in __init__
  Module bika.health.browser.batch.batchfolder, line 88, in folderitems
  Module bika.lims.browser.batchfolder, line 136, in folderitems
  Module bika.lims.browser.bika_listing, line 854, in folderitems
  Module bika.lims.browser.bika_listing, line 1077, in _folderitems
  Module Products.CMFPlone.CatalogTool, line 389, in searchResults
  Module Products.ZCatalog.ZCatalog, line 604, in searchResults
  Module Products.ZCatalog.Catalog, line 916, in searchResults
  Module Products.ZCatalog.Catalog, line 889, in _getSortIndex
CatalogError: Unknown sort_on index (BatchID)
```