### PR TITLE
SearchableText index moved to the base dictionary in LIMS

### DIFF
--- a/bika/health/catalog/patient_catalog.py
+++ b/bika/health/catalog/patient_catalog.py
@@ -36,7 +36,6 @@ _indexes_dict = {
     'getFullname': 'FieldIndex',
     # (values from PatientIdentifiers field)
     'getPatientIdentifiers': 'KeywordIndex',
-    'SearchableText': 'ZCTextIndex'
 }
 # Defining the columns for this catalog
 _columns_list = [


### PR DESCRIPTION
Accept after https://github.com/naralabs/bika.lims/pull/94

SearchableText is defined in the base index, so it is easier to define new indexes for other content_types.

This PR also defines the method for this indexe in Analysis Request objects, so it is possible to filter them using plone's searchbox