### PR TITLE
NMRL-322 UnboundLocalError in Samples view: local variable 'ar' referenced before assignment

### DIFF
--- a/bika/health/browser/samples/folder_view.py
+++ b/bika/health/browser/samples/folder_view.py
@@ -26,7 +26,7 @@ class SamplesView(BaseView):
             'toggle': True}
         self.columns['getDoctor'] = {
             'title': _('Doctor'),
-            'sortable': False, 
+            'sortable': False,
             'toggle': True}
         for rs in self.review_states:
             i = rs['columns'].index('getSampleID') + 1
@@ -99,16 +99,19 @@ class SamplesView(BaseView):
         # invalidated/retracted
         wf = getToolByName(self.context, 'portal_workflow')
         rawars = sample.getAnalysisRequests()
+        target_ar = None
         ars = [ar for ar in rawars \
                if (wf.getInfoFor(ar, 'review_state') != 'invalid')]
         if (len(ars) == 0 and len(rawars) > 0):
             # All ars are invalid. Retrieve the info from the last one
-            ar = rawars[len(rawars) - 1]
+            target_ar = rawars[len(rawars) - 1]
         elif (len(ars) > 1):
             # There's more than one valid AR
             # That couldn't happen never. Anyway, retrieve the last one
-            ar = ars[len(ars) - 1]
+            target_ar = ars[len(ars) - 1]
         elif (len(ars) == 1):
             # One ar matches
-            ar = ars[0]
-        return ar.Schema()['Patient'].get(ar) if ar else None
+            target_ar = ars[0]
+        if target_ar:
+            return target_ar.Schema()['Patient'].get(target_ar)
+        return None


### PR DESCRIPTION
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 813, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 1fcc7583a38f7da5f1911a876bf004c8.py, line 425, in render
  Module 3ba6dba684b83f1d319fbeea87951906.py, line 1172, in render_master
  Module 3ba6dba684b83f1d319fbeea87951906.py, line 484, in render_content
  Module 1fcc7583a38f7da5f1911a876bf004c8.py, line 355, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1294, in contents_table
  Module bika.lims.browser.bika_listing, line 1447, in __init__
  Module bika.health.browser.samples.folder_view, line 66, in folderitems
  Module bika.health.browser.samples.folder_view, line 114, in getPatient
UnboundLocalError: local variable 'ar' referenced before assignment
```