### PR TITLE
NMRL-371 Unknown sort_on indexes

### DIFF
--- a/bika/health/browser/batch/batchfolder.py
+++ b/bika/health/browser/batch/batchfolder.py
@@ -9,12 +9,12 @@ class BatchFolderContentsView(BaseView):
         super(BatchFolderContentsView, self).__init__(context, request)
         self.title = self.context.translate(_("Cases"))
         self.columns = {
-            'BatchID': {'title': _('Case ID')},
+            'BatchID': {'title': _('Case ID'), 'index': 'getId'},
             'getPatientID': {'title': _('Patient ID'), 'toggle': True},
             'getClientPatientID': {'title': _('Client PID'), 'toggle': True},
-            'Patient': {'title': _('Patient')},
-            'Doctor': {'title': _('Doctor')},
-            'Client': {'title': _('Client')},
+            'Patient': {'title': _('Patient'), 'index': 'getPatientTitle'},
+            'Doctor': {'title': _('Doctor'), 'index': 'getDoctorTitle'},
+            'Client': {'title': _('Client'), 'index': 'getClientTitle'},
             'OnsetDate': {'title': _('Onset Date')},
             'state_title': {'title': _('State'), 'sortable': False},
             'created': {'title': _('Created'), },


### PR DESCRIPTION
Added index names where they are not the same as Column name.

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.batchfolder, line 107, in __call__
  Module bika.lims.browser.bika_listing, line 810, in __call__
  Module bika.lims.browser.bika_listing, line 1273, in contents_table
  Module bika.lims.browser.bika_listing, line 1367, in __init__
  Module bika.health.browser.batch.batchfolder, line 89, in folderitems
  Module bika.lims.browser.batchfolder, line 139, in folderitems
  Module bika.lims.browser.bika_listing, line 885, in folderitems
  Module bika.lims.browser.bika_listing, line 1098, in _folderitems
  Module bika.lims.browser.bika_listing, line 1048, in _fetch_brains
  Module Products.CMFPlone.CatalogTool, line 389, in searchResults
  Module Products.ZCatalog.ZCatalog, line 604, in searchResults
  Module Products.ZCatalog.Catalog, line 916, in searchResults
  Module Products.ZCatalog.Catalog, line 889, in _getSortIndex
CatalogError: Unknown sort_on index (Patient)
```