### PR TITLE
Allow contacts to create patients

### DIFF
--- a/bika/health/profiles/default/metadata.xml
+++ b/bika/health/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3.2.0.1706</version>
+  <version>3.2.0.1710</version>
   <dependencies>
     <dependency>profile-bika.lims:default</dependency>
   </dependencies>

--- a/bika/health/profiles/default/workflow_csv/bika_patient_workflow.csv
+++ b/bika/health/profiles/default/workflow_csv/bika_patient_workflow.csv
@@ -20,4 +20,4 @@ BIKA: View Batches,N,N,Y,Y,Y,N,N,N,N,N,N,N,N,N,N,N,Y
 View,N,N,Y,Y,Y,N,N,N,N,Y,Y,N,N,N,N,N,Y
 Access Contents Information,N,N,Y,Y,Y,N,N,N,N,Y,Y,N,N,N,N,N,Y
 List folder contents,N,N,Y,Y,Y,N,N,N,N,Y,Y,N,N,N,N,N,Y
-Modify portal content,N,N,Y,Y,Y,N,N,N,N,Y,Y,N,N,N,N,N,N
+Modify portal content,N,N,Y,Y,Y,N,N,N,N,Y,Y,N,N,N,N,N,Y

--- a/bika/health/setuphandlers.py
+++ b/bika/health/setuphandlers.py
@@ -230,7 +230,7 @@ def setupHealthPermissions(context):
 
     # /patients
     mp = portal.patients.manage_permission
-    mp(AddPatient, ['Manager', 'LabManager', 'LabClerk'], 1)
+    mp(AddPatient, ['Manager', 'LabManager', 'LabClerk', 'Client'], 1)
     mp(EditPatient, ['Manager', 'LabManager', 'LabClerk', 'Client'], 1)
     mp(ViewPatients, ['Manager', 'LabManager', 'Owner', 'LabClerk', 'Doctor', 'RegulatoryInspector', 'Client'], 1)
     mp(ViewAnalysisRequests, ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor', 'Client'], 0)
@@ -240,7 +240,7 @@ def setupHealthPermissions(context):
     mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor', 'Client'], 0)
     mp('Access contents information', ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor', 'Client'], 0)
     mp(permissions.ListFolderContents, ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor'], 0)
-    mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor'], 0)
+    mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector', 'Doctor', 'Client'], 0)
     portal.patients.reindexObject()
 
     # /doctors

--- a/bika/health/upgrade/configure.zcml
+++ b/bika/health/upgrade/configure.zcml
@@ -58,4 +58,11 @@
         handler="bika.health.upgrade.v3_2_0_1706.upgrade"
         profile="bika.health:default"/>
 
+<genericsetup:upgradeStep
+        title="Upgrade to Bika Health 3.2.0.1710"
+        source="3.2.0.1706"
+        destination="3.2.0.1710"
+        handler="bika.health.upgrade.v3_2_0_1710.upgrade"
+        profile="bika.health:default"/>
+
 </configure>

--- a/bika/health/upgrade/v3_2_0_1710.py
+++ b/bika/health/upgrade/v3_2_0_1710.py
@@ -1,0 +1,51 @@
+# This file is part of Bika Health
+#
+# Copyright 2011-2017 by its authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from bika.health import logger
+from bika.health.interfaces import IPatient
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+from plone.api.portal import get_tool
+from Products.CMFCore.permissions import ModifyPortalContent
+
+product = 'bika.health'
+version = '3.2.0.1710'
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    ut = UpgradeUtils(portal)
+    ufrom = ut.getInstalledVersion(product)
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ufrom, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
+
+    # Allow Client Contacts to Add Patients
+    roles = ['Manager', 'LabManager', 'LabClerk', 'RegulatoryInspector',
+             'Doctor', 'Client']
+    pm = portal.patients.manage_permission
+    pm(ModifyPortalContent, roles, 0)
+
+    # Allow Client Contacts to Edit Patients
+    wf_tool = get_tool('portal_workflow')
+    workflow = wf_tool.getWorkflowById('bika_patient_workflow')
+    state = workflow.states['active']
+    state.permission_roles[ModifyPortalContent] = tuple(roles)
+
+    # Update role mappings for previously created patients
+    for patient in portal.patients:
+        if IPatient.providedBy(patient):
+            workflow.updateRoleMappingsFor(patient)
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
The PR gives privileges to Client Contacts to create and edit Patients. Note that a given Client Contact can only access the Client he/she belongs to. Therefore, they will only be able to list, create and edit patients for that Client.