### PR TITLE
NMRL-408 Can't search using Client Patient ID in batches listing

### DIFF
--- a/bika/health/browser/batch/batchfolder.py
+++ b/bika/health/browser/batch/batchfolder.py
@@ -84,8 +84,6 @@ class BatchFolderContentsView(BaseView):
         ]
 
     def folderitems(self):
-        self.filter_indexes = None
-
         items = BaseView.folderitems(self)
         pm = getToolByName(self.context, "portal_membership")
         member = pm.getAuthenticatedMember()

--- a/bika/health/content/batch.py
+++ b/bika/health/content/batch.py
@@ -79,7 +79,11 @@ def getPatientUID(instance):
 
 @indexer(IBatch)
 def getPatientTitle(instance):
-    item = instance.Schema()['Patient'].get(instance)
+    return PatientTitleGetter(instance)
+
+
+def PatientTitleGetter(obj):
+    item = obj.Schema()['Patient'].get(obj)
     value = item and item.Title() or ''
     return value
 
@@ -122,6 +126,7 @@ def getClientTitle(instance):
 @indexer(IBatch)
 def getClientPatientID(instance):
     return ClientPatientIDGetter(instance)
+
 
 def ClientPatientIDGetter(obj):
     item = obj.Schema()['Patient'].get(obj)
@@ -503,7 +508,8 @@ def get_site_from_context(context):
 
 class BatchSearchableText(object):
     """
-
+    This class is used as an adapter in order to obtain field or methods
+    results as string values for SearchableText index in batches (cases).
     """
     implements(IBatchSearchableText)
 
@@ -515,8 +521,10 @@ class BatchSearchableText(object):
 
     def get_plain_text_fields(self):
         """
-        This function returns the field names to be used in searchable text.
-        :return: A tuple of strings as field names.
+        This function returns field or methods results to be used in
+        searchable text.
+        :return: A list of strings as searchable text options.
         """
         client_patient_id = ClientPatientIDGetter(self.context)
-        return [client_patient_id]
+        client_patient_name = PatientTitleGetter(self.context)
+        return [client_patient_id, client_patient_name]

--- a/bika/health/content/configure.zcml
+++ b/bika/health/content/configure.zcml
@@ -27,6 +27,13 @@
     <adapter factory=".batch.getClientUID" name="getClientUID" />
     <adapter factory=".batch.getClientTitle" name="getClientTitle" />
 
+    <adapter
+      factory=".batch.BatchSearchableText"
+      provides="bika.lims.interfaces.IBatchSearchableText"
+      for="bika.lims.interfaces.IBatch"
+      name="HealthBatchSearchableText"
+    />
+
     <adapter factory=".client.getClientID" name="getClientID" />
 
     <adapter factory=".analysis.AnalysisSchemaExtender" />


### PR DESCRIPTION
First accept https://github.com/naralabs/bika.lims/pull/268
This PR fixes: NMRL-411/408

The search input in batches lists wasn't working for two reasons, first because it was disabled and second because searchable text was only working for LIMS add-on. This PR creates an adapter in order to use Searchable texts from health addon.