### PR TITLE
NMRL-410 Can't search using Client Patient ID in patient listing

### DIFF
--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -909,7 +909,7 @@ class Patient(Person):
         # plain text fields we index from ourself,
         # a list of accessor methods of the class
         plain_text_fields = ("Title", "getFullname", "getId",
-                             "getPrimaryReferrerID", "getPrimaryReferrerTitle")
+                             "getPrimaryReferrerID", "getPrimaryReferrerTitle", "getClientPatientID")
 
         def read(accessor):
             """

--- a/bika/health/upgrade/v3_2_0_1710.py
+++ b/bika/health/upgrade/v3_2_0_1710.py
@@ -11,6 +11,7 @@ from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 from plone.api.portal import get_tool
 from Products.CMFCore.permissions import ModifyPortalContent
+from bika.health.catalog import CATALOG_PATIENT_LISTING
 
 product = 'bika.health'
 version = '3.2.0.1710'
@@ -46,6 +47,13 @@ def upgrade(tool):
     for patient in portal.patients:
         if IPatient.providedBy(patient):
             workflow.updateRoleMappingsFor(patient)
+
+    # Reindex patient catalog and bika catalog
+    logger.info("Reindexing {0}, {1}".format(CATALOG_PATIENT_LISTING, 'bika_catalog'))
+    ut.reindexcatalog[CATALOG_PATIENT_LISTING] = 'SearchableText'
+    ut.reindexcatalog['bika_catalog'] = 'SearchableText'
+    ut.refreshCatalogs()
+    logger.info("Catalogs updated")
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
In order to be able to search by the Client Patient ID in the patient's listing the field ```getClientPatientID``` has  been included in the SearchableText.

This pull request also includes the upgrade required to reindex both bika catalog and patient's catalog SearchableText index.

Associated PR: #31 (This why bika catalog is also reindexed)